### PR TITLE
Fix typos in SQL and Fetch APIs

### DIFF
--- a/ZapLib/Fetch.cs
+++ b/ZapLib/Fetch.cs
@@ -253,7 +253,7 @@ namespace ZapLib
             Qs = qs;
             if (files != null) ContentType = "multipart/form-data";
             Request.Method = HttpMethod.Post;
-            SetRequestContnet(data, files);
+            SetRequestContent(data, files);
             return Send() ? Response.Content.ReadAsStringAsync().Result : default;
         }
 
@@ -271,7 +271,7 @@ namespace ZapLib
             Qs = qs;
             Accept = "application/json";
             Request.Method = HttpMethod.Post;
-            SetRequestContnet(data, files);
+            SetRequestContent(data, files);
             return Send() ? JsonConvert.DeserializeObject<T>(Response.Content.ReadAsStringAsync().Result) : default;
         }
 
@@ -286,7 +286,7 @@ namespace ZapLib
         {
             Qs = qs;
             Request.Method = HttpMethod.Delete;
-            SetRequestContnet(data, files);
+            SetRequestContent(data, files);
             return Send() ? Response.Content.ReadAsStringAsync().Result : default;
         }
 
@@ -304,7 +304,7 @@ namespace ZapLib
             Qs = qs;
             Accept = "application/json";
             Request.Method = HttpMethod.Delete;
-            SetRequestContnet(data, files);
+            SetRequestContent(data, files);
             return Send() ? JsonConvert.DeserializeObject<T>(Response.Content.ReadAsStringAsync().Result) : default;
         }
 
@@ -319,7 +319,7 @@ namespace ZapLib
         {
             Qs = qs;
             Request.Method = HttpMethod.Put;
-            SetRequestContnet(data, files);
+            SetRequestContent(data, files);
             return Send() ? Response.Content.ReadAsStringAsync().Result : null;
         }
 
@@ -337,7 +337,7 @@ namespace ZapLib
             Qs = qs;
             Accept = "application/json";
             Request.Method = HttpMethod.Put;
-            SetRequestContnet(data, files);
+            SetRequestContent(data, files);
             return Send() ? JsonConvert.DeserializeObject<T>(Response.Content.ReadAsStringAsync().Result) : default;
         }
 
@@ -354,7 +354,7 @@ namespace ZapLib
             Qs = qs;
             if (files != null) ContentType = "multipart/form-data";
             Request.Method = new HttpMethod("PATCH");
-            SetRequestContnet(data, files);
+            SetRequestContent(data, files);
             return Send() ? Response.Content.ReadAsStringAsync().Result : default;
         }
 
@@ -372,7 +372,7 @@ namespace ZapLib
             Qs = qs;
             Accept = "application/json";
             Request.Method = new HttpMethod("PATCH");
-            SetRequestContnet(data, files);
+            SetRequestContent(data, files);
             return Send() ? JsonConvert.DeserializeObject<T>(Response.Content.ReadAsStringAsync().Result) : default;
         }
 
@@ -485,7 +485,7 @@ namespace ZapLib
         /// </summary>
         /// <param name="data">資料</param>
         /// <param name="files">檔案</param>
-        public void SetRequestContnet(object data = null, object files = null)
+        public void SetRequestContent(object data = null, object files = null)
         {
             if (string.IsNullOrWhiteSpace(ContentType)) ContentType = "application/json";
             if (files != null) ContentType = "multipart/form-data";

--- a/ZapLib/SQL.cs
+++ b/ZapLib/SQL.cs
@@ -167,9 +167,9 @@ namespace ZapLib
         /// <summary>
         /// 手動連線資料庫，可以使用 IsConn 來確認使否連線成功
         /// </summary>
-        public void Connet()
+        public void Connect()
         {
-            connString = BuildconnString();
+            connString = BuildConnectionString();
             LogExecTime lextime = new LogExecTime($"DB Connection time\r\nTraceCode: {TraceCode}");
             try
             {
@@ -199,7 +199,7 @@ namespace ZapLib
         /// 建構連線字串
         /// </summary>
         /// <returns>重新補全過的連線字串</returns>
-        public string BuildconnString()
+        public string BuildConnectionString()
         {
             if (!builder.ContainsKey("Connect Timeout")) builder.Add("Connect Timeout", Timeout);
             else builder["Connect Timeout"] = Timeout;
@@ -312,7 +312,7 @@ namespace ZapLib
         public T[] QuickQuery<T>(string sql, object param = null, bool isfetchall = true)
         {
             T[] data = null;
-            Connet();
+            Connect();
             if (IsConn)
             {
                 try
@@ -372,7 +372,7 @@ namespace ZapLib
         public dynamic[] QuickDynamicQuery(string sql, object param = null, bool isfetchall = true)
         {
             dynamic[] data = null;
-            Connet();
+            Connect();
             if (IsConn)
             {
                 try
@@ -428,7 +428,7 @@ namespace ZapLib
         public T QuickExec<T>(string sql, object param = null)
         {
             T obj = default;
-            Connet();
+            Connect();
             if (IsConn)
             {
                 try
@@ -471,7 +471,7 @@ namespace ZapLib
         public dynamic QuickDynamicExec(string sql, object param = null, object output = null)
         {
             dynamic obj = null;
-            Connet();
+            Connect();
             if (IsConn)
             {
                 try
@@ -511,7 +511,7 @@ namespace ZapLib
         public bool QuickBulkCopy(DataTable data, string tableName)
         {
             bool result = false;
-            Connet();
+            Connect();
             if (IsConn)
             {
                 LogExecTime lextime2 = new LogExecTime($"Exec BulkCopy: {tableName}\r\nRows.Count: {data.Rows.Count}\r\nTraceCode: {TraceCode}");

--- a/ZapLibUnitTest/SQLTests.cs
+++ b/ZapLibUnitTest/SQLTests.cs
@@ -91,8 +91,8 @@ namespace ZapLib.Tests
             SQL db1 = new SQL(Host1, DBName1, User1, Password1);
             SQL db2 = new SQL(Host2, DBName2, User2, Password2);
 
-            db1.Connet();
-            db2.Connet();
+            db1.Connect();
+            db2.Connect();
 
             if (db1.IsConn && db2.IsConn)
             {
@@ -164,7 +164,7 @@ namespace ZapLib.Tests
 
             SQL db = new SQL(Host, DBName, User, Password, true);
 
-            db.Connet();
+            db.Connect();
 
             if (db.IsConn)
             {
@@ -232,7 +232,7 @@ namespace ZapLib.Tests
         }
 
         [TestMethod()]
-        public void BuildconnStringTest()
+        public void BuildConnectionStringTest()
         {
             SQL db = new SQL();
 
@@ -249,7 +249,7 @@ namespace ZapLib.Tests
             for (int i = 0; i < testpool.Length; i++)
             {
                 string cs = testpool[i];
-                string res = new SQL(cs).BuildconnString();
+                string res = new SQL(cs).BuildConnectionString();
                 Trace.WriteLine(cs);
                 Trace.WriteLine(res);
                 Assert.IsTrue(res.Contains(exps[i]));
@@ -261,18 +261,18 @@ namespace ZapLib.Tests
 
 
         [TestMethod()]
-        public void BuildconnStringTest2()
+        public void BuildConnectionStringTest2()
         {
 
             string testsql = "Data Source=10.190.173.134\\support6;Initial Catalog=Drive;User ID=sa;Password=123";
             var db = new SQL(testsql);
-            string connstr = db.BuildconnString();
+            string connstr = db.BuildConnectionString();
             Trace.WriteLine(testsql + "\n" + connstr);
             Assert.IsTrue(connstr.Contains("ReadWrite"));
 
             db.SQLReadOnly = true;
 
-            string connstr2 = db.BuildconnString();
+            string connstr2 = db.BuildConnectionString();
             Trace.WriteLine(testsql + "\n" + connstr2);
 
             Assert.IsTrue(connstr2.Contains("ReadWrite"));
@@ -282,7 +282,7 @@ namespace ZapLib.Tests
 
 
         [TestMethod()]
-        public void BuildconnStringTest3()
+        public void BuildConnectionStringTest3()
         {
             //SQL db = new SQL();
 
@@ -295,7 +295,7 @@ namespace ZapLib.Tests
             Trace.WriteLine("case 1");
             string cs = testpool[0];
             var db = new SQL(cs);
-            string res = db.BuildconnString();
+            string res = db.BuildConnectionString();
             Trace.WriteLine("conn str: " + cs);
             Trace.WriteLine("build str: " + res);
             Trace.WriteLine("timeout: " + db.Timeout);
@@ -304,7 +304,7 @@ namespace ZapLib.Tests
             Trace.WriteLine("case 2");
             cs = testpool[1];
             db = new SQL(cs);
-            res = db.BuildconnString();
+            res = db.BuildConnectionString();
             Trace.WriteLine("conn str: " + cs);
             Trace.WriteLine("build str: " + res);
             Trace.WriteLine("timeout: " + db.Timeout);
@@ -316,7 +316,7 @@ namespace ZapLib.Tests
             cs = testpool[0];
             db = new SQL(cs);
             db.Timeout = 666;
-            res = db.BuildconnString();
+            res = db.BuildConnectionString();
             Trace.WriteLine("conn str: " + cs);
             Trace.WriteLine("build str: " + res);
             Trace.WriteLine("timeout: " + db.Timeout);
@@ -327,7 +327,7 @@ namespace ZapLib.Tests
             cs = testpool[1];
             db = new SQL(cs);
             db.Timeout = 222;
-            res = db.BuildconnString();
+            res = db.BuildConnectionString();
             Trace.WriteLine("conn str: " + cs);
             Trace.WriteLine("build str: " + res);
             Trace.WriteLine("timeout: " + db.Timeout);


### PR DESCRIPTION
## Summary
- rename `Connet` -> `Connect`
- rename `BuildconnString` -> `BuildConnectionString`
- rename `SetRequestContnet` -> `SetRequestContent`
- update tests for new names

## Testing
- `dotnet test ZapLib.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452277846c832f83989ba658665e6c