### PR TITLE
Chore/upgrade vulnerable deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 改版紀錄
 
+## `2.5.0-beta2`
+
+安全性更新 (Security fixes) — 升級多個有 CVE 公告的相依套件，無公開 API 變動，使用者可直接更新。
+
+升級內容：
+
+| 套件 | 原版本 | 新版本 | CVE / Advisory |
+| --- | --- | --- | --- |
+| `Newtonsoft.Json` | 12.0.1 | 13.0.3 | [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr) (high) |
+| `Microsoft.Owin` (+ `.Security`, `.Host.SystemWeb`) | 4.2.0 | 4.2.3 | [GHSA-3rq8-h3gj-r5c6](https://github.com/advisories/GHSA-3rq8-h3gj-r5c6) (high) |
+| `MailKit` | 3.3.0 | 4.16.0 | [GHSA-9j88-vvj5-vhgr](https://github.com/advisories/GHSA-9j88-vvj5-vhgr) (moderate) |
+| `MimeKit` | 3.3.0 | 4.16.0 | [GHSA-gmc6-fwg3-75m5](https://github.com/advisories/GHSA-gmc6-fwg3-75m5) (high), [GHSA-g7hc-96xr-gvvx](https://github.com/advisories/GHSA-g7hc-96xr-gvvx) (moderate) |
+
+備註：
+
+* MailKit/MimeKit 由 3.x 升級到 4.x，原本相依的 `Portable.BouncyCastle 1.9.0` 改為 `BouncyCastle.Cryptography 2.6.2`，並一併拉新 `System.Buffers` / `System.Memory` / `System.Numerics.Vectors` / `System.Runtime.CompilerServices.Unsafe` / `System.Threading.Tasks.Extensions`，並新增 `System.Formats.Asn1`。
+* `Mailer` class 公開介面 (`Send`, `AddAttachments`, `SecureSocketOption` 等) 維持不變，使用方式完全相同。
+* 仍維持 .NET Framework 4.7.2 目標，未變更 TFM。
+
 ## `2.5.0-beta1`
 
 1. 新增全新類別 `OracleSQL`，用於連線 Oracle 資料庫，使用方式比照既有的 `SQL` class 設計，主要差異如下：

--- a/ZapLib/Properties/AssemblyInfo.cs
+++ b/ZapLib/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.5.0-beta1")]
+[assembly: AssemblyInformationalVersion("2.5.0-beta2")]

--- a/ZapLib/ZapLib.csproj
+++ b/ZapLib/ZapLib.csproj
@@ -47,14 +47,14 @@
     <Reference Include="Microsoft.AspNet.SignalR.SystemWeb, Version=2.4.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.SignalR.SystemWeb.2.4.3\lib\net45\Microsoft.AspNet.SignalR.SystemWeb.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.4.2.0\lib\net45\Microsoft.Owin.dll</HintPath>
+    <Reference Include="Microsoft.Owin, Version=4.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.2.3\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.2.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.2.3\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.4.2.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security, Version=4.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.4.2.3\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
     <Reference Include="MimeKit, Version=3.3.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
       <HintPath>..\packages\MimeKit.3.3.0\lib\net47\MimeKit.dll</HintPath>

--- a/ZapLib/ZapLib.csproj
+++ b/ZapLib/ZapLib.csproj
@@ -59,8 +59,8 @@
     <Reference Include="MimeKit, Version=3.3.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
       <HintPath>..\packages\MimeKit.3.3.0\lib\net47\MimeKit.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Oracle.ManagedDataAccess">
       <HintPath>..\packages\Oracle.ManagedDataAccess.23.26.200\lib\net472\Oracle.ManagedDataAccess.dll</HintPath>

--- a/ZapLib/ZapLib.csproj
+++ b/ZapLib/ZapLib.csproj
@@ -35,11 +35,11 @@
     <Reference Include="AegisImplicitMail">
       <HintPath>..\packages\AIM.1.1.1\AegisImplictMail\bin\Release\netstandard2.0\AegisImplicitMail.dll</HintPath>
     </Reference>
-    <Reference Include="BouncyCastle.Crypto, Version=1.9.0.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
-      <HintPath>..\packages\Portable.BouncyCastle.1.9.0\lib\net40\BouncyCastle.Crypto.dll</HintPath>
+    <Reference Include="BouncyCastle.Cryptography, Version=2.0.0.0, Culture=neutral, PublicKeyToken=072edcf4a5328938, processorArchitecture=MSIL">
+      <HintPath>..\packages\BouncyCastle.Cryptography.2.6.2\lib\net461\BouncyCastle.Cryptography.dll</HintPath>
     </Reference>
-    <Reference Include="MailKit, Version=3.3.0.0, Culture=neutral, PublicKeyToken=4e064fe7c44a8f1b, processorArchitecture=MSIL">
-      <HintPath>..\packages\MailKit.3.3.0\lib\net47\MailKit.dll</HintPath>
+    <Reference Include="MailKit, Version=4.16.0.0, Culture=neutral, PublicKeyToken=4e064fe7c44a8f1b, processorArchitecture=MSIL">
+      <HintPath>..\packages\MailKit.4.16.0\lib\net47\MailKit.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.Core, Version=2.4.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.4.3\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
@@ -56,8 +56,8 @@
     <Reference Include="Microsoft.Owin.Security, Version=4.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.Security.4.2.3\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="MimeKit, Version=3.3.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
-      <HintPath>..\packages\MimeKit.3.3.0\lib\net47\MimeKit.dll</HintPath>
+    <Reference Include="MimeKit, Version=4.16.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
+      <HintPath>..\packages\MimeKit.4.16.0\lib\net47\MimeKit.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -69,31 +69,34 @@
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    <Reference Include="System.Buffers, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Formats.Asn1, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Formats.Asn1.8.0.1\lib\net462\System.Formats.Asn1.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    <Reference Include="System.Numerics.Vectors, Version=4.1.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.6.1\lib\net462\System.Numerics.Vectors.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.Text.Encoding.CodePages, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Text.Encoding.CodePages.4.5.1\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
     </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.6.0\lib\net462\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/ZapLib/ZapLib.nuspec
+++ b/ZapLib/ZapLib.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>ZapLib</id>
-    <version>2.5.0-beta1</version>
+    <version>2.5.0-beta2</version>
     <title>ZapLib</title>
     <authors>Zap Lin</authors>
     <owners>Zap Lin</owners>
@@ -14,6 +14,7 @@
       🔧 Source &amp; Issues: https://github.com/LinZap/ZapLib
     </description>
     <releaseNotes>
+      v2.5.0-beta2 — security: patches CVEs in MailKit, MimeKit, Microsoft.Owin, Newtonsoft.Json (no public API changes)
       v2.5.0-beta1 — NEW OracleSQL class for Oracle database queries (managed driver, no Oracle Client needed)
       v2.4.12 (Stable) — SQL AlwaysOn read-only routing support
       v1.22.0 (LTS for .NET 4.5)

--- a/ZapLib/app.config
+++ b/ZapLib/app.config
@@ -12,11 +12,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.3.0" newVersion="4.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -28,7 +28,31 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.3.0" newVersion="4.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="MimeKit" publicKeyToken="bede1c8a46c66814" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.16.0.0" newVersion="4.16.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="MailKit" publicKeyToken="4e064fe7c44a8f1b" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.16.0.0" newVersion="4.16.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ZapLib/packages.config
+++ b/ZapLib/packages.config
@@ -10,9 +10,9 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net472" />
-  <package id="Microsoft.Owin" version="4.2.0" targetFramework="net472" />
-  <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.0" targetFramework="net472" />
-  <package id="Microsoft.Owin.Security" version="4.2.0" targetFramework="net472" />
+  <package id="Microsoft.Owin" version="4.2.3" targetFramework="net472" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.3" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security" version="4.2.3" targetFramework="net472" />
   <package id="MimeKit" version="3.3.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="Oracle.ManagedDataAccess" version="23.26.200" targetFramework="net472" />

--- a/ZapLib/packages.config
+++ b/ZapLib/packages.config
@@ -14,7 +14,7 @@
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.0" targetFramework="net472" />
   <package id="Microsoft.Owin.Security" version="4.2.0" targetFramework="net472" />
   <package id="MimeKit" version="3.3.0" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="Oracle.ManagedDataAccess" version="23.26.200" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Portable.BouncyCastle" version="1.9.0" targetFramework="net472" />

--- a/ZapLib/packages.config
+++ b/ZapLib/packages.config
@@ -1,8 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AIM" version="1.1.1" targetFramework="net472" />
+  <package id="BouncyCastle.Cryptography" version="2.6.2" targetFramework="net472" />
   <package id="jQuery" version="3.6.0" targetFramework="net472" />
-  <package id="MailKit" version="3.3.0" targetFramework="net472" />
+  <package id="MailKit" version="4.16.0" targetFramework="net472" />
   <package id="Microsoft.AspNet.SignalR" version="2.4.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.SignalR.Core" version="2.4.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.SignalR.JS" version="2.4.3" targetFramework="net472" />
@@ -13,15 +14,15 @@
   <package id="Microsoft.Owin" version="4.2.3" targetFramework="net472" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.3" targetFramework="net472" />
   <package id="Microsoft.Owin.Security" version="4.2.3" targetFramework="net472" />
-  <package id="MimeKit" version="3.3.0" targetFramework="net472" />
+  <package id="MimeKit" version="4.16.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="Oracle.ManagedDataAccess" version="23.26.200" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="Portable.BouncyCastle" version="1.9.0" targetFramework="net472" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="System.Buffers" version="4.6.1" targetFramework="net472" />
+  <package id="System.Formats.Asn1" version="8.0.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.6.3" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net472" />
   <package id="System.Text.Encoding.CodePages" version="4.5.1" targetFramework="net472" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.6.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
## Summary

Patches the four security advisories flagged by `nuget restore` in the docs-site CI build (run 69890515431). All four vulnerable packages are bumped to a net472-compatible patched release; no source-code changes were required.

| Package | Old | New | Advisory | Severity | Source change? |
| --- | --- | --- | --- | --- | --- |
| `Newtonsoft.Json` | 12.0.1 | 13.0.3 | [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr) | high | no |
| `Microsoft.Owin` | 4.2.0 | 4.2.3 | [GHSA-3rq8-h3gj-r5c6](https://github.com/advisories/GHSA-3rq8-h3gj-r5c6) | high | no |
| `Microsoft.Owin.Security` | 4.2.0 | 4.2.3 | (transitively affected) | high | no |
| `Microsoft.Owin.Host.SystemWeb` | 4.2.0 | 4.2.3 | (kept in sync with Owin family) | — | no |
| `MailKit` | 3.3.0 | 4.16.0 | [GHSA-9j88-vvj5-vhgr](https://github.com/advisories/GHSA-9j88-vvj5-vhgr) | moderate | no |
| `MimeKit` | 3.3.0 | 4.16.0 | [GHSA-gmc6-fwg3-75m5](https://github.com/advisories/GHSA-gmc6-fwg3-75m5), [GHSA-g7hc-96xr-gvvx](https://github.com/advisories/GHSA-g7hc-96xr-gvvx) | high + moderate | no |

`Mailer.cs` was reviewed against the MailKit 4.0 break list. The only relevant API change — `SmtpClient.Send()` now returns `string` instead of `void` — does not affect us because the caller (`send_mail()`) ignores the return value. All other APIs we use (`Connect`, `Authenticate`, `Disconnect`, `MimeMessage`, `Multipart`, `TextPart`, `MimePart`, `MimeContent`, `MimeUtils`, `ContentDisposition`, `ContentEncoding`, `InternetAddressList`, `SecureSocketOptions`) are source-compatible across 3.x → 4.x.

## Transitive dependency changes (forced by MimeKit/MailKit 4.x)

- `Portable.BouncyCastle 1.9.0` → `BouncyCastle.Cryptography 2.6.2` (package renamed by upstream; new assembly name, new PublicKeyToken — csproj `<HintPath>` and `Reference Include` updated)
- `System.Buffers 4.5.1` → `4.6.1`
- `System.Memory 4.5.4` → `4.6.3`
- `System.Numerics.Vectors 4.5.0` → `4.6.1`
- `System.Runtime.CompilerServices.Unsafe 4.5.3` → `6.1.2`
- `System.Threading.Tasks.Extensions 4.5.4` → `4.6.0`
- `System.Formats.Asn1` (new direct dep of MailKit) → `8.0.1`

`app.config` binding redirects updated for all of the above.

## Constraints honored

- ✅ Still net472. No TFM change.
- ✅ Microsoft.Owin stays on the 4.2.x line (no 5.x exists).
- ✅ `Interface-SSO` left untouched.
- ✅ One commit per package upgrade, except MailKit + MimeKit are bundled (4.x MailKit depends on 4.x MimeKit — they cannot be reverted independently).

## Commits

- `ce8155c` deps: bump Newtonsoft.Json 12.0.1 -> 13.0.3
- `46ee5cc` deps: bump Microsoft.Owin family 4.2.0 -> 4.2.3
- `0d3782b` deps: bump MailKit + MimeKit 3.3.0 -> 4.16.0 (+ transitive deps + binding redirects)
- `ccc0bad` release: bump nuspec to 2.5.0-beta2 + CHANGELOG entry

## Test plan

- [x] `msbuild ZapLib\ZapLib.csproj /p:Configuration=Release` succeeds with no warnings or errors after each commit.
- [ ] **Could not run unit tests.** `ZapLibUnitTest` references `Interface-SSO 1.0.0-beta2`, which only exists on the company's internal NuGet feed; `nuget restore` for that project fails in this environment. The ZapLib library itself builds clean.
- [ ] `ZapLibTests2` not built (no MailKit/MimeKit/Owin usage; deferred).
- [ ] DocFX site build (`docfx docs/docfx.json`) not exercised locally — please verify in CI.

## Not done (intentionally out of scope)

- SDK-style csproj migration / PackageReference conversion
- Dependabot configuration
- Test-project dependency sync (test projects still pin Newtonsoft.Json 12.0.1 / Microsoft.Owin 4.2.0; they restore separately and don't ship in the NuGet package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)